### PR TITLE
MD formatting fix

### DIFF
--- a/position/README.md
+++ b/position/README.md
@@ -1,13 +1,13 @@
 [![GoDoc](https://godoc.org/github.com/andrewbackes/chess/board?status.svg)](https://godoc.org/github.com/andrewbackes/chess/board)
 
-#Position
+# Position
 
 Position is a go package that provides a chess board and game state 
 representation. With this package you can work with chess boards, squares
 and moves. Internally, bitboards are used for piece location so that move
 generation is quick.
 
-##How to get it
+## How to get it
 If you have your GOPATH set in the recommended way ([golang.org](https://golang.org/doc/code.html#GOPATH)):
 
 ```go get github.com/andrewbackes/chess/position```


### PR DESCRIPTION
While having a look at your interesting library I noticed there's a little formatting problem with the README: the hash does not have any white space after it. The effect is that Github does not correctly format the document.